### PR TITLE
Updated settings in vcpkg-configuration.json file to use cmsis-toolbox 2.9.0 a.o.

### DIFF
--- a/.ci/vcpkg-configuration.json
+++ b/.ci/vcpkg-configuration.json
@@ -7,11 +7,11 @@
         }
     ],
     "requires": {
-        "arm:tools/open-cmsis-pack/cmsis-toolbox": "^2.6.0",
-        "arm:tools/arm/mdk-toolbox":" ^1.0.0",
-        "arm:tools/kitware/cmake": "^3.28.4",
-        "arm:tools/ninja-build/ninja": "^1.12.0",
-        "arm:compilers/arm/armclang": "^6.22.0",
-        "arm:compilers/arm/arm-none-eabi-gcc": "^13.3.1"
+        "arm:tools/open-cmsis-pack/cmsis-toolbox": "^2.9.0",
+        "arm:tools/arm/mdk-toolbox":" ^1.1.0",
+        "arm:tools/kitware/cmake": "^3.31.5",
+        "arm:tools/ninja-build/ninja": "^1.12.1",
+        "arm:compilers/arm/armclang": "^6.24.0",
+        "arm:compilers/arm/arm-none-eabi-gcc": "^14.2.1"
     }
 }

--- a/.github/workflows/Test-Examples.yml
+++ b/.github/workflows/Test-Examples.yml
@@ -62,13 +62,13 @@ jobs:
         working-directory: ./
         run: |
           mkdir -p ./CI/Examples/Blinky
-          cp -rf ./BSP/Examples/Blinky/* ./CI/Examples/Blinky/
+          cp -a ./BSP/Examples/Blinky/. ./CI/Examples/Blinky/
 
       - name: Build Blinky AC6
         if: always()
         working-directory: ./CI/Examples/Blinky
         run: |
-          cbuild ./Blinky.csolution.yml --packs --update-rte --packs --toolchain AC6 --rebuild
+          cbuild ./Blinky.csolution.yml --packs --toolchain AC6 --rebuild
 
       - name: Upload Artifact of the Blinky AC6 build
         if: always()

--- a/.github/workflows/Test-MDK-Middleware-RefApps.yml
+++ b/.github/workflows/Test-MDK-Middleware-RefApps.yml
@@ -19,10 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         solution: [
-#          {name: FileSystem, dir: FileSystem, layer_ac6: ./BSP/Layers/Default, layer_gcc: ./.ci/Layers/Default_GCC},
-#          {name: Network,    dir: Network,    layer_ac6: ./BSP/Layers/Default, layer_gcc: ./.ci/Layers/Default_GCC},
-          {name: USB_Device, dir: USB/Device, layer_ac6: ./BSP/Layers/Default, layer_gcc: ./.ci/Layers/Default_GCC},
-#         {name: USB_Host,   dir: USB/Host,   layer_ac6: ./BSP/Layers/Default, layer_gcc: ./.ci/Layers/Default_GCC}
+          {name: USB_Device, dir: USB/Device, layer_ac6: ./BSP/Layers/Default, layer_gcc: ./.ci/Layers/Default_GCC}
         ]
 
     steps:
@@ -78,15 +75,20 @@ jobs:
       - name: Copy example structure to CI/MW-RefApps/ folder
         working-directory: ./
         run: |
-          mkdir -p ./CI/MW-RefApps/Examples/
           mkdir -p ./CI/MW-RefApps/Examples/${{ matrix.solution.dir }}/Board/
-          cp -rf ./MDK-Middleware/Examples/* ./CI/MW-RefApps/Examples/
+          cp -a ./MDK-Middleware/Examples/* ./CI/MW-RefApps/Examples/
 
+      - name: Replace specific csolution files
+        working-directory: ./
+        run: |
           if [ -e ./.ci/MW-RefApps/Examples/${{ matrix.solution.dir }}/${{ matrix.solution.name }}.csolution.yml ]
           then
-             cp -rf ./.ci/MW-RefApps/Examples/${{ matrix.solution.dir }}/${{ matrix.solution.name }}.csolution.yml ./CI/MW-RefApps/Examples/${{ matrix.solution.dir }}/${{ matrix.solution.name }}.csolution.yml
+             cp -f ./.ci/MW-RefApps/Examples/${{ matrix.solution.dir }}/${{ matrix.solution.name }}.csolution.yml ./CI/MW-RefApps/Examples/${{ matrix.solution.dir }}/${{ matrix.solution.name }}.csolution.yml
           fi
 
+      - name: Add the board layer to the ${{ matrix.solution.dir }}/${{ matrix.solution.name }}.csolution.yml
+        working-directory: ./
+        run: |
           sed -i "s|target-types:|&\n    - type: $TARGET_BOARD\n      board: $TARGET_BOARD\n      variables:\n        - Board-Layer: \$SolutionDir()\$/Board/Board.clayer.yml|"  ./CI/MW-RefApps/Examples/${{ matrix.solution.dir }}/${{ matrix.solution.name }}.csolution.yml
 
       - name: Update board layer for ${{ matrix.solution.name }} AC6 build test

--- a/Examples/Blinky/.cmsis/Blinky+STM32L073Z-EVAL.dbgconf
+++ b/Examples/Blinky/.cmsis/Blinky+STM32L073Z-EVAL.dbgconf
@@ -1,0 +1,48 @@
+// File: STM32L0x1_0x2_0x3_DBGMCU.ini
+// Version: 1.0.0
+// Note: refer to STM32L0x1 reference manual (RM0377)
+//       refer to STM32L0x1 datasheet
+//       refer to STM32L0x2 reference manual (RM0376)
+//       refer to STM32L0x2 datasheet
+//       refer to STM32L0x3 reference manual (RM0367)
+//       refer to STM32L0x3 datasheet
+
+// <<< Use Configuration Wizard in Context Menu >>>
+
+// <h> Debug MCU configuration register (DBGMCU_CR)
+//                                   <i> Reserved bits must be kept at reset value
+//   <o.2>  DBG_STANDBY              <i> Debug Standby Mode
+//   <o.1>  DBG_STOP                 <i> Debug Stop Mode
+//   <o.0>  DBG_SLEEP                <i> Debug Sleep Mode
+// </h>
+DbgMCU_CR = 0x00000007;
+
+// <h> Debug MCU APB1 freeze register (DBGMCU_APB1_FZ)
+//                                   <i> Reserved bits must be kept at reset value
+//   <o.31> DBG_LPTIMER_STOP         <i> LPTIM1 counter stopped when core is halted
+//   <o.30> DBG_I2C3_STOP            <i> I2C3 SMBUS timeout mode stopped when core is halted
+//   <o.22> DBG_I2C2_STOP            <i> I2C2 SMBUS timeout mode stopped when core is halted
+//   <o.21> DBG_I2C1_STOP            <i> I2C1 SMBUS timeout mode stopped when core is halted
+//   <o.12> DBG_IWDG_STOP            <i> Debug independent watchdog stopped when core is halted
+//   <o.11> DBG_WWDG_STOP            <i> Debug window watchdog stopped when core is halted
+//   <o.10> DBG_RTC_STOP             <i> Debug RTC stopped when core is halted
+//   <o.5>  DBG_TIM7_STOP            <i> TIM7 counter stopped when core is halted
+//   <o.4>  DBG_TIM6_STOP            <i> TIM6 counter stopped when core is halted
+//   <o.1>  DBG_TIM3_STOP            <i> TIM3 counter stopped when core is halted
+//   <o.0>  DBG_TIM2_STOP            <i> TIM2 counter stopped when core is halted
+// </h>
+DbgMCU_APB1_Fz = 0x00000000;
+
+// <h> Debug MCU APB2 freeze register (DBGMCU_APB2_FZ)
+//                                   <i> Reserved bits must be kept at reset value
+//   <o.5> DBG_TIM22_STOP            <i> TIM22 counter stopped when core is halted
+//   <o.2> DBG_TIM21_STOP            <i> TIM21 counter stopped when core is halted
+// </h>
+DbgMCU_APB2_Fz = 0x00000000;
+
+// <h> Flash Download Options
+//   <o.0> Option Byte Loading       <i> Launch the Option Byte Loading after a Flash Download by setting the OBL_LAUNCH bit (causes a reset)
+// </h>
+DoOptionByteLoading = 0x00000000;
+
+// <<< end of configuration section >>>

--- a/Examples/Blinky/.cmsis/Blinky+STM32L073Z-EVAL.dbgconf.base@0.0.0
+++ b/Examples/Blinky/.cmsis/Blinky+STM32L073Z-EVAL.dbgconf.base@0.0.0
@@ -1,0 +1,48 @@
+// File: STM32L0x1_0x2_0x3_DBGMCU.ini
+// Version: 1.0.0
+// Note: refer to STM32L0x1 reference manual (RM0377)
+//       refer to STM32L0x1 datasheet
+//       refer to STM32L0x2 reference manual (RM0376)
+//       refer to STM32L0x2 datasheet
+//       refer to STM32L0x3 reference manual (RM0367)
+//       refer to STM32L0x3 datasheet
+
+// <<< Use Configuration Wizard in Context Menu >>>
+
+// <h> Debug MCU configuration register (DBGMCU_CR)
+//                                   <i> Reserved bits must be kept at reset value
+//   <o.2>  DBG_STANDBY              <i> Debug Standby Mode
+//   <o.1>  DBG_STOP                 <i> Debug Stop Mode
+//   <o.0>  DBG_SLEEP                <i> Debug Sleep Mode
+// </h>
+DbgMCU_CR = 0x00000007;
+
+// <h> Debug MCU APB1 freeze register (DBGMCU_APB1_FZ)
+//                                   <i> Reserved bits must be kept at reset value
+//   <o.31> DBG_LPTIMER_STOP         <i> LPTIM1 counter stopped when core is halted
+//   <o.30> DBG_I2C3_STOP            <i> I2C3 SMBUS timeout mode stopped when core is halted
+//   <o.22> DBG_I2C2_STOP            <i> I2C2 SMBUS timeout mode stopped when core is halted
+//   <o.21> DBG_I2C1_STOP            <i> I2C1 SMBUS timeout mode stopped when core is halted
+//   <o.12> DBG_IWDG_STOP            <i> Debug independent watchdog stopped when core is halted
+//   <o.11> DBG_WWDG_STOP            <i> Debug window watchdog stopped when core is halted
+//   <o.10> DBG_RTC_STOP             <i> Debug RTC stopped when core is halted
+//   <o.5>  DBG_TIM7_STOP            <i> TIM7 counter stopped when core is halted
+//   <o.4>  DBG_TIM6_STOP            <i> TIM6 counter stopped when core is halted
+//   <o.1>  DBG_TIM3_STOP            <i> TIM3 counter stopped when core is halted
+//   <o.0>  DBG_TIM2_STOP            <i> TIM2 counter stopped when core is halted
+// </h>
+DbgMCU_APB1_Fz = 0x00000000;
+
+// <h> Debug MCU APB2 freeze register (DBGMCU_APB2_FZ)
+//                                   <i> Reserved bits must be kept at reset value
+//   <o.5> DBG_TIM22_STOP            <i> TIM22 counter stopped when core is halted
+//   <o.2> DBG_TIM21_STOP            <i> TIM21 counter stopped when core is halted
+// </h>
+DbgMCU_APB2_Fz = 0x00000000;
+
+// <h> Flash Download Options
+//   <o.0> Option Byte Loading       <i> Launch the Option Byte Loading after a Flash Download by setting the OBL_LAUNCH bit (causes a reset)
+// </h>
+DoOptionByteLoading = 0x00000000;
+
+// <<< end of configuration section >>>

--- a/Examples/Blinky/Blinky.csolution.yml
+++ b/Examples/Blinky/Blinky.csolution.yml
@@ -1,6 +1,6 @@
 # A solution is a collection of related projects that share same base configuration.
 solution:
-  created-for: CMSIS-Toolbox@2.6.0
+  created-for: CMSIS-Toolbox@2.9.0
   cdefault:
 
   # List of tested compilers that can be selected

--- a/Keil.STM32L073Z-EVAL_BSP.pdsc
+++ b/Keil.STM32L073Z-EVAL_BSP.pdsc
@@ -24,7 +24,6 @@
       - updated settings in vcpkg-configuration.json file to use cmsis-toolbox 2.9.0
       - updated RTE_Components.h file.
       - added Blinky+STM32L073Z-EVAL.dbgconf and Blinky+STM32L073Z-EVAL.dbgconf.base@0.0.0 files.
-      - updated Test-Examples.yml and Test-MDK-Middleware-RefApps.yml workflows.
     </release>
   </releases>
 

--- a/Keil.STM32L073Z-EVAL_BSP.pdsc
+++ b/Keil.STM32L073Z-EVAL_BSP.pdsc
@@ -21,6 +21,10 @@
       - rename thread IDs
       - modify app_main_thread (replace loop forever)
       - add DWARF-5 debug information
+      - updated settings in vcpkg-configuration.json file to use cmsis-toolbox 2.9.0
+      - updated RTE_Components.h file.
+      - added Blinky+STM32L073Z-EVAL.dbgconf and Blinky+STM32L073Z-EVAL.dbgconf.base@0.0.0 files.
+      - updated Test-Examples.yml and Test-MDK-Middleware-RefApps.yml workflows.
     </release>
   </releases>
 

--- a/Keil.STM32L073Z-EVAL_BSP.pdsc
+++ b/Keil.STM32L073Z-EVAL_BSP.pdsc
@@ -21,7 +21,6 @@
       - rename thread IDs
       - modify app_main_thread (replace loop forever)
       - add DWARF-5 debug information
-      - updated settings in vcpkg-configuration.json file to use cmsis-toolbox 2.9.0
       - updated RTE_Components.h file.
       - added Blinky+STM32L073Z-EVAL.dbgconf and Blinky+STM32L073Z-EVAL.dbgconf.base@0.0.0 files.
     </release>


### PR DESCRIPTION
- Updated settings in vcpkg-configuration.json file to use cmsis-toolbox 2.9.0. 
- Updated RTE_Components.h file. 
- Added Blinky+STM32L073Z-EVAL.dbgconf and Blinky+STM32L073Z-EVAL.dbgconf.base@0.0.0 files. 
- Updated Test-Examples.yml and Test-MDK-Middleware-RefApps.yml workflows. 
- Update release notes in Keil.STM32L073Z-EVAL_BSP.pdsc file.